### PR TITLE
pause resume logic

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -133,4 +133,5 @@ export const constants: StringKeyMap = {
         ev('MATCH_CASE_INSENSITIVE_ADDRESSES')
     ),
     RESEED_QUEUE_CHANNEL: 'spec_new_reseed_job',
+    SEED_CURSOR_STATUS_CHANNEL: 'spec_seed_cursor_status',
 }

--- a/src/lib/db/spec/seedCursors.ts
+++ b/src/lib/db/spec/seedCursors.ts
@@ -210,3 +210,34 @@ export async function failedSeedCursorsExist(): Promise<boolean> {
         return false
     }
 }
+
+export async function checkIfSeedCursorIsPaused(id: string) {
+    try {
+        const results = await seedCursors().select('status').where('id', id).limit(1)
+        const status = results[0]?.status
+        return status && status === 'paused' ? true : false
+    } catch (err) {
+        logger.error(`Error checking if seed_cursor (id=${id}) is paused: ${err}`)
+        return false
+    }
+}
+
+export async function pauseSeedCursor(id: string) {
+    try {
+        await db.transaction(async (tx) => {
+            await seedCursors(tx).update('is_paused', true).where('id', id)
+        })
+    } catch (err) {
+        logger.error(`Error pausing seed_cursor (id=${id}): ${err}`)
+    }
+}
+
+export async function resumeSeedCursor(id: string) {
+    try {
+        await db.transaction(async (tx) => {
+            await seedCursors(tx).update('is_paused', false).where('id', id)
+        })
+    } catch (err) {
+        logger.error(`Error unpausing seed_cursor (id=${id}): ${err}`)
+    }
+}


### PR DESCRIPTION
Adds the ability to pause and resume a backfill / seeding. If a cursor is paused, it will disconnect from the backend connection and not receive updates until setting the cursor back to in-progress.