### PR TITLE
Multichain Foreign Table Seed Batching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@spec.dev/spec",
-    "version": "0.0.19",
+    "version": "0.0.20",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@spec.dev/spec",
-            "version": "0.0.19",
+            "version": "0.0.20",
             "license": "MIT",
             "dependencies": {
                 "@ltd/j-toml": "1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@spec.dev/spec",
     "description": "Spec",
-    "version": "0.0.19",
+    "version": "0.0.20",
     "keywords": [
         "javascript",
         "typescript",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -54,7 +54,7 @@ export const constants: StringKeyMap = {
 
     // The number of records to use in a single batch when seeding live
     // columns with a *foreign table*.
-    FOREIGN_SEED_INPUT_BATCH_SIZE: Number(ev('FOREIGN_SEED_INPUT_BATCH_SIZE', 100)),
+    FOREIGN_SEED_INPUT_BATCH_SIZE: Number(ev('FOREIGN_SEED_INPUT_BATCH_SIZE', 10)),
 
     // The 'limit' to use (alongside 'offset') when fetching an entire live table from scratch.
     FROM_SCRATCH_SEED_INPUT_BATCH_SIZE: Number(ev('FROM_SCRATCH_SEED_INPUT_BATCH_SIZE', 100000)),

--- a/src/lib/services/SeedTableService.ts
+++ b/src/lib/services/SeedTableService.ts
@@ -592,12 +592,15 @@ class SeedTableService {
 
         const foreignInputColPaths = inputColNames.map(colName => [foreignTablePath, colName].join('.'))
         let chainIdColName = null
-        for (const colPath of foreignInputColPaths) {
-            const inputProperties = (this.colPathsToFunctionInputArgs[colPath] || []).map(entry => entry.property)
-            if (inputProperties.inludes('chainId')) {
-                chainIdColName = colPath.split('.').pop()
-                break
+        for (const colPathsToFunctionInputArgs of this.colPathsToFunctionInputArgs) {
+            for (const colPath of foreignInputColPaths) { 
+                const inputProperties = (colPathsToFunctionInputArgs[colPath] || []).map(entry => entry.property)
+                if (inputProperties.includes('chainId')) {
+                    chainIdColName = colPath.split('.').pop()
+                    break
+                }
             }
+            if (chainIdColName) break
         }
 
         const sharedErrorContext = { error: null }

--- a/src/lib/services/SeedTableService.ts
+++ b/src/lib/services/SeedTableService.ts
@@ -625,14 +625,17 @@ class SeedTableService {
             }
 
             // Reduce the batch to the first N records that share the same chain id.
+            let reducedBatchSize = false
             if (chainIdColName) {
                 let chainBatchInputRecords = []
                 let batchChainId = batchInputRecords[0][chainIdColName]
+                const prevBatchInputRecordsLength = batchInputRecords.length
                 for (const inputRecord of batchInputRecords) {
                     if (inputRecord[chainIdColName] !== batchChainId) break
                     chainBatchInputRecords.push(inputRecord)
                 }
                 batchInputRecords = chainBatchInputRecords
+                reducedBatchSize = batchInputRecords.length < prevBatchInputRecordsLength
             }
 
             if (batchInputRecords === null) {
@@ -657,7 +660,7 @@ class SeedTableService {
             }
 
             this.cursor += batchInputRecords.length
-            const isLastBatch = batchInputRecords.length < seedInputBatchSize
+            const isLastBatch = !reducedBatchSize && (batchInputRecords.length < seedInputBatchSize)
 
             // Map the input records to their reference key values so that records added
             // to the seed table can easily find/assign their associated foreign keys.

--- a/src/lib/services/SeedTableService.ts
+++ b/src/lib/services/SeedTableService.ts
@@ -590,11 +590,15 @@ class SeedTableService {
             seedInputBatchSize = Math.min(seedInputBatchSize, 20)
         }
 
-        const foreignInputColPaths = inputColNames.map(colName => [foreignTablePath, colName].join('.'))
+        const foreignInputColPaths = inputColNames.map((colName) =>
+            [foreignTablePath, colName].join('.')
+        )
         let chainIdColName = null
         for (const colPathsToFunctionInputArgs of this.colPathsToFunctionInputArgs) {
-            for (const colPath of foreignInputColPaths) { 
-                const inputProperties = (colPathsToFunctionInputArgs[colPath] || []).map(entry => entry.property)
+            for (const colPath of foreignInputColPaths) {
+                const inputProperties = (colPathsToFunctionInputArgs[colPath] || []).map(
+                    (entry) => entry.property
+                )
                 if (inputProperties.includes('chainId')) {
                     chainIdColName = colPath.split('.').pop()
                     break
@@ -660,7 +664,7 @@ class SeedTableService {
             }
 
             this.cursor += batchInputRecords.length
-            const isLastBatch = !reducedBatchSize && (batchInputRecords.length < seedInputBatchSize)
+            const isLastBatch = !reducedBatchSize && batchInputRecords.length < seedInputBatchSize
 
             // Map the input records to their reference key values so that records added
             // to the seed table can easily find/assign their associated foreign keys.


### PR DESCRIPTION
Batch foreign table seeded Live Tables by `chainId` when walking down records.